### PR TITLE
Adding retry counter for BMS Slave communication before timeout

### DIFF
--- a/BMS Workspace-git/bms-1227-fw/include/pl455.h
+++ b/BMS Workspace-git/bms-1227-fw/include/pl455.h
@@ -20,6 +20,7 @@
 #include "datatypes.h"
 #include "hal_stdtypes.h"
 #include "stdint.h"
+#include "stdbool.h"
 
 // User defines
 #define FRMWRT_SGL_R    0x00 // single device write with response
@@ -39,6 +40,9 @@ void WakePL455();
 void CommClear(void);
 void CommReset(void);
 BOOL GetFaultStat();
+
+bool getBMSinitFlag(void);
+void setBMSinitFlag(bool state);
 
 uint16  B2SWORD(uint16 wIN);
 uint32 B2SDWORD(uint32 dwIN);

--- a/BMS Workspace-git/bms-1227-fw/source/phantom_freertos.c
+++ b/BMS Workspace-git/bms-1227-fw/source/phantom_freertos.c
@@ -32,7 +32,7 @@ void xphTimerInit(void)
                        "RTDS_Timer",
                        /* The timer period in ticks, must be
                        greater than 0. */
-                       pdMS_TO_TICKS(10),
+                       pdMS_TO_TICKS(1),
                        /* The timers will auto-reload themselves
                        when they expire. */
                        pdFALSE,

--- a/BMS Workspace-git/bms-1227-fw/source/phantom_pl455.c
+++ b/BMS Workspace-git/bms-1227-fw/source/phantom_pl455.c
@@ -40,6 +40,7 @@ void BMS_init(){
         _enable_IRQ();
         gioInit();
         sciInit();
+
         while ((scilinREG->FLR & 0x4) == 4);
 
         _enable_interrupt_();
@@ -425,9 +426,9 @@ void BMS_Read_All(){
 }
 
 void BMS_Read_All_NP(){
-        int nSent = 0;
+        uint32_t  wTemp = 0;
 
-        nSent = WriteReg(0, 2, TOTALBOARDS-1, 1, FRMWRT_ALL_R); // send sync sample command
+        WriteReg(0, 2, TOTALBOARDS-1, 1, FRMWRT_ALL_R); // send sync sample command
 
         sciReceive(scilinREG, BMSByteArraySize*TOTALBOARDS, MultipleSlaveReading); //1 header, 32x2 cells, 2x16 AUX, 4 dig die, 4 ana die, 2 CRC
 
@@ -507,7 +508,8 @@ void BMS_Read_All_NP(){
 
              uint8 auxCount = TOTALAUX*TOTALBOARDS-1;
          for (i = TOTALBOARDS-1; i > -1; i--){
-             for (j = voltageLoopCounter; j < auxLoopCounter; j++) {
+             for (j = voltageLoopCounter; j < auxLoopCounter; j++)
+             {
                  int tempVal = MultipleSlaveReading[j+BMSByteArraySize*i]*16*16 + MultipleSlaveReading[j+1+BMSByteArraySize*i];
                  double div = tempVal/65535.0; //FFFF
                  double fin = div * 5.0;
@@ -519,7 +521,9 @@ void BMS_Read_All_NP(){
              }
 
              double anaDieTemp = ((((MultipleSlaveReading[auxLoopCounter+2+BMSByteArraySize*i]*16*16 + MultipleSlaveReading[auxLoopCounter+3+BMSByteArraySize*i])/65535.0)*5) - 1.8078) * 147.514;
-             }
+         }
+
+         ReadReg(0, 10, &wTemp, 1, 0);
 }
 
 void BMS_Read_Single(uint8_t device){

--- a/BMS Workspace-git/bms-1227-fw/source/sci.c
+++ b/BMS Workspace-git/bms-1227-fw/source/sci.c
@@ -428,6 +428,7 @@ uint32 sciIsRxReady(sciBASE_t *sci)
 /* USER CODE BEGIN (13) */
 /* USER CODE END */
 
+
     return sci->FLR & (uint32)SCI_RX_INT;
 }
 

--- a/BMS Workspace-git/bms-1227-fw/source/sys_main.c
+++ b/BMS Workspace-git/bms-1227-fw/source/sys_main.c
@@ -168,12 +168,15 @@ void vSensorReadTask(void *pvParameters){
     // Initialize the xLastWakeTime variable with the current time;
     xLastWakeTime = xTaskGetTickCount();
 
-    int nchars;
-    char stbuf[64];
     do{
-    vTaskDelayUntil(&xLastWakeTime, xFrequency);
+        vTaskDelayUntil(&xLastWakeTime, xFrequency);
 
-    BMS_Read_All_NP();
+        if(!getBMSinitFlag())
+        {
+            BMS_init();
+        }
+
+        BMS_Read_All_NP();
     }while(1);
 
 }


### PR DESCRIPTION
Timeout is implemented by waiting for the UART receive interrupt to fire giving it 5000 runs through the waiting loop, if there's no response, print a message saying a timeout occurs and reinitiallize the BMS Slaves. If the BMS slaves are unplugged or are powered off, Master will keep on attempting to reinitiallize.