### PR TITLE
Set up global state machine & integrate charger (no interrupt)

### DIFF
--- a/BMS Workspace-git/bms-1227-fw/Phantom_drivers/include/bms_data.h
+++ b/BMS Workspace-git/bms-1227-fw/Phantom_drivers/include/bms_data.h
@@ -20,8 +20,6 @@ typedef enum BMSState_t
 
 typedef struct bmsFlags
 {
-	uint8_t BALANCE_EN; // If 1, then cell balancing is enabled (only done during charging), if 0, then cell balancing is disabled
-						// TODO: Set this = 1 if state machine evaluates to CHARGING state
 	uint8_t FUSE_FAULT; // If 1, then fuse has blown, if 0, then fuses are intact
 	uint8_t THREE_SECOND_FLAG; // If 1, then a cell has been in fault for longer than 3 seconds, else 0
 							   // TODO: If 1, put BMS in FAULT state
@@ -37,7 +35,6 @@ typedef struct bmsData
 	float remainingRunTime; // Remaining run time estimation, expressing in minutes
 
 	double minimumCellVoltage; // Minimum voltage of all cells from most recent query
-	BMSState_t state; // The current state of the BMS
 } bmsData;
 
 typedef struct bmsSlaveVoltage
@@ -55,6 +52,7 @@ typedef struct bms_data
     bmsSlaveVoltage SlaveVoltage;
 } bms_data;
 
+BMSState_t BMSState;
 bms_data* BMSDataPtr;
 
 void initBMSData();

--- a/BMS Workspace-git/bms-1227-fw/Phantom_drivers/include/phantom_pl455.h
+++ b/BMS Workspace-git/bms-1227-fw/Phantom_drivers/include/phantom_pl455.h
@@ -46,8 +46,8 @@ typedef struct BMS_FLAGS{
 } BMS_FLAGS;
 
 void BMS_init(void);
-void BMS_Read_Single(uint8_t device, bool printToUART);
-void BMS_Read_All(bool printToUART, bool update);
+void BMS_Read_Single(uint8_t device);
+void BMS_Read_All(bool update);
 //void BMS_Read_All_NP_SIM();
 void BMS_ProcessState(void);
 void BMS_ReconnectSlave(uint8_t device);

--- a/BMS Workspace-git/bms-1227-fw/Phantom_drivers/include/sys_main.h
+++ b/BMS Workspace-git/bms-1227-fw/Phantom_drivers/include/sys_main.h
@@ -19,8 +19,6 @@
 #include "os_timer.h"
 #include "phantom_freertos.h"
 
-typedef enum {CHARGING, RUNNING, FAULT} State;
-
 #define CLI_ENABLE true
 
 enum TASK_PRIORITIES{
@@ -29,12 +27,19 @@ enum TASK_PRIORITIES{
 };
 
 /*********************************************************************************
+ *                          DEBUG PRINTING DEFINES
+ *********************************************************************************/
+#define TASK_PRINT  0
+#define STATE_PRINT 0
+
+/*********************************************************************************
  *                          TASK HEADER DECLARATIONS
  *********************************************************************************/
-void vStateMachineTask(void *);  // This task will evaluate the state machine and decide whether or not to change states
-void vSensorReadTask(void *);    // This task will read all the sensors in the vehicle (except for the APPS which requires more critical response)
-void vSOCTask(void *); 			 // This task will evaluate the state of charge of the vehicle battery
-void vBalanceTask(void *);		 // This task will perform passive cell balancing
+void vStateMachineTask(void *);  		// This task will evaluate the state machine and decide whether or not to change states
+void vSensorReadTask(void *);    		// This task will read all the sensors in the vehicle (except for the APPS which requires more critical response)
+void vSOCTask(void *); 			 		// This task will evaluate the state of charge of the vehicle battery
+void vChargerTask(void *pvParameters);	// This task will call function to charge cells
+void vBalanceTask(void *);		 		// This task will perform passive cell balancing
 
 
 /*********************************************************************************

--- a/BMS Workspace-git/bms-1227-fw/Phantom_drivers/source/bms_data.c
+++ b/BMS Workspace-git/bms-1227-fw/Phantom_drivers/source/bms_data.c
@@ -12,9 +12,9 @@ void initBMSData()
 	/***********************************************************
      *              FLAG INITIALIZATION
      ***********************************************************/
-	BMSDataPtr->Flags.BALANCE_EN = 0;
 	BMSDataPtr->Flags.FUSE_FAULT = 0;
 	BMSDataPtr->Flags.THREE_SECOND_FLAG = 0;
+	BMSDataPtr->Flags.TOTAL_CELL_ERROR_FLAG = 0;
 	BMSDataPtr->Flags.BAD_SLAVE_CONNECTION_FLAG = 0;
 
 	/***********************************************************
@@ -23,7 +23,6 @@ void initBMSData()
 	BMSDataPtr->Data.SOC = 0;
 	BMSDataPtr->Data.remainingRunTime = 0;
 	BMSDataPtr->Data.minimumCellVoltage = 5;
-	BMSDataPtr->Data.state = BMS_RUNNING;
 
 	/***********************************************************
      *              SLAVE VOLTAGE INITIALIZATION

--- a/BMS Workspace-git/bms-1227-fw/Phantom_drivers/source/phantom_freertos.c
+++ b/BMS Workspace-git/bms-1227-fw/Phantom_drivers/source/phantom_freertos.c
@@ -15,7 +15,7 @@
 #include "sys_main.h"
 #include "bms_data.h"
 
-extern bms_data* BMSDataPtr;
+extern BMSState_t BMSState;
 
 void xphRtosInit(void)
 {
@@ -128,8 +128,15 @@ void xphTaskInit(void)
       while(1);
   }
 
-  if (BMSDataPtr->Flags.BALANCE_EN == 1)
+  if (BMSState == BMS_CHARGING)
   {
+      if (xTaskCreate(vChargerTask, (const char*)"ChargerTask",  240, NULL,  (STATE_MACHINE_TASK_PRIORITY), NULL) != pdTRUE)
+      {
+          // if xTaskCreate returns something != pdTRUE, then the task failed, wait in this infinite loop..
+          // probably need a better error handler
+          sciSend(sciREG,23,(unsigned char*)"ChargerTask Creation Failed.\r\n");
+          while(1);
+      }
       if (xTaskCreate(vBalanceTask, (const char*)"BalanceTask",  240, NULL,  (STATE_MACHINE_TASK_PRIORITY), NULL) != pdTRUE)
       {
           // if xTaskCreate returns something != pdTRUE, then the task failed, wait in this infinite loop..

--- a/BMS Workspace-git/bms-1227-fw/Phantom_drivers/source/phantom_pl455.c
+++ b/BMS Workspace-git/bms-1227-fw/Phantom_drivers/source/phantom_pl455.c
@@ -522,10 +522,9 @@ void BMS_Slaves_Heartbeat(void)
  * values in BMS data structure
  * TODO: Finalize function description before pushing
  *
- * @param       printToUART     set true to enable printing values to UART
  * @param       update          set true to query the slaves for new values, set false to obtain previously queried-values
  */
-void BMS_Read_All(bool printToUART, bool update)
+void BMS_Read_All(bool update)
 {
     char buf[100];
     int nDev_ID;
@@ -558,7 +557,7 @@ void BMS_Read_All(bool printToUART, bool update)
     for (i = TOTALBOARDS-1; i > -1; i--) {
         for (j = 0; j < voltageLoopCounter; j = j + 2) {
             if (j == 0) {
-                if (printToUART) {
+                if (TASK_PRINT) {
                     snprintf(buf, 30, "Header -> Decimal: %d, Hex: %X\n\n\r", MultipleSlaveReading[j+BMSByteArraySize*i], MultipleSlaveReading[j+BMSByteArraySize*i]);
                     UARTSend(PC_UART, buf);
                 }
@@ -586,7 +585,7 @@ void BMS_Read_All(bool printToUART, bool update)
                 BMSDataPtr->Data.minimumCellVoltage = fin;
             }
 
-            if (printToUART) {
+            if (TASK_PRINT) {
                 snprintf(buf, 40, "Cell %d: Hex: %X %X Voltage: %fV \n\r", totalCellCount, MultipleSlaveReading[j+BMSByteArraySize*i], MultipleSlaveReading[j+1+BMSByteArraySize*i], fin);
                 UARTSend(PC_UART, buf);
                 UARTSend(PC_UART, "\n\r");
@@ -596,7 +595,7 @@ void BMS_Read_All(bool printToUART, bool update)
                 BMS.CELL_OVERVOLTAGE_FLAG[cellCount - 1] = true;
                 BMS.TOTAL_CELL_ERROR_COUNTER++;
 
-                if (printToUART) {
+                if (TASK_PRINT) {
                     snprintf(buf, 20, "Cell %d Overvoltage\n\r", totalCellCount);
                     UARTSend(PC_UART, buf);
                     UARTSend(PC_UART, "\n\r");
@@ -606,7 +605,7 @@ void BMS_Read_All(bool printToUART, bool update)
                 BMS.CELL_UNDERVOLTAGE_FLAG[cellCount - 1] = true;
                 BMS.TOTAL_CELL_ERROR_COUNTER++;
 
-                if (printToUART) {
+                if (TASK_PRINT) {
                     snprintf(buf, 21, "Cell %d Undervoltage\n\r", totalCellCount);
                     UARTSend(PC_UART, buf);
                     UARTSend(PC_UART, "\n\r");
@@ -641,7 +640,7 @@ void BMS_Read_All(bool printToUART, bool update)
 
             // TODO: Check for high temperature -> Indicate on BMS.TOTAL_CELL_ERROR_COUNTER
 
-            if (printToUART) {
+            if (TASK_PRINT) {
                 snprintf(buf, 70, "AUX %d: Hex: %X %X Voltage: %fV Resistance: %f Ohms\n\n\r", auxCount, MultipleSlaveReading[j+BMSByteArraySize*i], MultipleSlaveReading[j+1+BMSByteArraySize*i], fin, resistance);
                 UARTSend(PC_UART, buf);
                 UARTSend(PC_UART, "\n\r");
@@ -653,7 +652,7 @@ void BMS_Read_All(bool printToUART, bool update)
         double digDieTemp = ((((MultipleSlaveReading[auxLoopCounter+BMSByteArraySize*i]*16*16 + MultipleSlaveReading[auxLoopCounter+1+BMSByteArraySize*i])/65535.0)*5) - 2.287) * 131.944;
         double anaDieTemp = ((((MultipleSlaveReading[auxLoopCounter+2+BMSByteArraySize*i]*16*16 + MultipleSlaveReading[auxLoopCounter+3+BMSByteArraySize*i])/65535.0)*5) - 1.8078) * 147.514;
         
-        if (printToUART) {
+        if (TASK_PRINT) {
             snprintf(buf, 50, "Digital Die: Hex: %X %X Temp: %f degrees C\n\r", MultipleSlaveReading[auxLoopCounter+BMSByteArraySize*i], MultipleSlaveReading[auxLoopCounter+1+BMSByteArraySize*i], digDieTemp);
             UARTSend(PC_UART, buf);
             UARTSend(PC_UART, "\n\r");
@@ -669,7 +668,7 @@ void BMS_Read_All(bool printToUART, bool update)
         BMSDataPtr->Flags.TOTAL_CELL_ERROR_FLAG = true;
     }
 
-    if (printToUART) {
+    if (TASK_PRINT) {
         snprintf(buf, 26, "NUMBER OF CELL ERRORS: %d\n\r", BMS.TOTAL_CELL_ERROR_COUNTER);
         UARTSend(PC_UART, buf);
         UARTSend(PC_UART, "\n\r");
@@ -685,9 +684,8 @@ void BMS_Read_All(bool printToUART, bool update)
  * TODO: Finalize function description before pushing
  *
  * @param       device          indicates which slave to read from
- * @param       printToUART     flag to enable or disable printing values to UART
  */
-void BMS_Read_Single(uint8_t device, bool printToUART)
+void BMS_Read_Single(uint8_t device)
 {
     int nSent = 0;
     char buf[100];
@@ -704,7 +702,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
 
     delayms(10); // for the tms to record all the data first
 
-    if (printToUART) {
+    if (TASK_PRINT) {
         snprintf(buf, 30, "Device number %d \n\r", device);
         UARTSend(PC_UART, buf);
     }
@@ -715,7 +713,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
     uint8 auxLoopCounter = voltageLoopCounter + TOTALAUX*2;
     for (j = 0; j < voltageLoopCounter; j = j + 2) {
         if (j == 0) {
-            if (printToUART) {
+            if (TASK_PRINT) {
                 snprintf(buf, 30, "Header -> Decimal: %d, Hex: %X\n\n", SingleSlaveReading[j], SingleSlaveReading[j]);
                 UARTSend(PC_UART, buf);
                 UARTSend(PC_UART, "\n\r");
@@ -727,7 +725,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
         double div = tempVal/65535.0; //FFFF
         double fin = div * 5.0;
 
-        if (printToUART) {
+        if (TASK_PRINT) {
             snprintf(buf, 40, "Cell %d: Hex: %X %X Voltage: %fV \n\r", cellCount, SingleSlaveReading[j], SingleSlaveReading[j+1], fin);
             UARTSend(PC_UART, buf);
             UARTSend(PC_UART, "\n\r");
@@ -737,7 +735,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
             BMS.CELL_OVERVOLTAGE_FLAG[cellCount - 1] = true;
             BMS.TOTAL_CELL_ERROR_COUNTER++;
 
-            if (printToUART) {
+            if (TASK_PRINT) {
                 snprintf(buf, 20, "Cell %d Overvoltage\n\r", cellCount);
                 UARTSend(PC_UART, buf);
                 UARTSend(PC_UART, "\n\r");
@@ -747,7 +745,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
             BMS.CELL_UNDERVOLTAGE_FLAG[cellCount - 1] = true;
             BMS.TOTAL_CELL_ERROR_COUNTER++;
 
-            if (printToUART) {
+            if (TASK_PRINT) {
                 snprintf(buf, 21, "Cell %d Undervoltage\n\r", cellCount);
                 UARTSend(PC_UART, buf);
                 UARTSend(PC_UART, "\n\r");
@@ -772,7 +770,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
         BMSDataPtr->Flags.TOTAL_CELL_ERROR_FLAG = true;
     }
 
-    if (printToUART) {
+    if (TASK_PRINT) {
         snprintf(buf, 26, "NUMBER OF CELL ERRORS: %d\n\r", BMS.TOTAL_CELL_ERROR_COUNTER);
         UARTSend(PC_UART, buf);
         UARTSend(PC_UART, "\n\r");
@@ -788,7 +786,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
 
         double resistance = 10000*(fin/(4.56-fin));
 
-        if (printToUART) {
+        if (TASK_PRINT) {
             snprintf(buf, 46, "AUX %d: Hex: %X %X Voltage: %fV Resistance: %f Ohms\n\n\r", auxCount, SingleSlaveReading[j], SingleSlaveReading[j+1], fin, resistance);
             UARTSend(PC_UART, buf);
             UARTSend(PC_UART, "\n\r");
@@ -799,7 +797,7 @@ void BMS_Read_Single(uint8_t device, bool printToUART)
     double digDieTemp = ((((SingleSlaveReading[37]*16*16 + SingleSlaveReading[38])/65535.0)*5) - 2.287) * 131.944;
     double anaDieTemp = ((((SingleSlaveReading[39]*16*16 + SingleSlaveReading[40])/65535.0)*5) - 1.8078) * 147.514;
 
-    if (printToUART) {
+    if (TASK_PRINT) {
         snprintf(buf, 50, "Digital Die: Hex: %X %X Temp: %f degrees C\n\r", SingleSlaveReading[37], SingleSlaveReading[38], digDieTemp);
         UARTSend(PC_UART, buf);
         UARTSend(PC_UART, "\n\r");

--- a/BMS Workspace-git/bms-1227-fw/halcogen_bms_launchpad/include/pinmux.h
+++ b/BMS Workspace-git/bms-1227-fw/halcogen_bms_launchpad/include/pinmux.h
@@ -295,7 +295,7 @@ extern "C" {
 #define PINMUX_PIN_53_EQEP1A                 ((uint32)((uint32)0x4U <<  PINMUX_PIN_53_SHIFT))
 
 #define PINMUX_PIN_54_MIBSPI3NENA            ((uint32)((uint32)0x1U <<  PINMUX_PIN_54_SHIFT))
-#define PINMUX_PIN_54_MIBSPI3NCS_5           ((uint32)((uint32)0x2U <<  PINMUX_PIN_54_SHIFT))
+#define CHARGER_ENABLE_PIN		             ((uint32)((uint32)0x2U <<  PINMUX_PIN_54_SHIFT))
 #define PINMUX_PIN_54_HET1_31                ((uint32)((uint32)0x4U <<  PINMUX_PIN_54_SHIFT))
 #define PINMUX_PIN_54_EQEP1B                 ((uint32)((uint32)0x8U <<  PINMUX_PIN_54_SHIFT))
 

--- a/BMS Workspace-git/bms-1227-fw/halcogen_bms_master/include/pinmux.h
+++ b/BMS Workspace-git/bms-1227-fw/halcogen_bms_master/include/pinmux.h
@@ -295,7 +295,7 @@ extern "C" {
 #define PINMUX_PIN_53_EQEP1A                 ((uint32)((uint32)0x4U <<  PINMUX_PIN_53_SHIFT))
 
 #define PINMUX_PIN_54_MIBSPI3NENA            ((uint32)((uint32)0x1U <<  PINMUX_PIN_54_SHIFT))
-#define PINMUX_PIN_54_MIBSPI3NCS_5           ((uint32)((uint32)0x2U <<  PINMUX_PIN_54_SHIFT))
+#define CHARGER_ENABLE_PIN                   ((uint32)((uint32)0x2U <<  PINMUX_PIN_54_SHIFT))
 #define PINMUX_PIN_54_HET1_31                ((uint32)((uint32)0x4U <<  PINMUX_PIN_54_SHIFT))
 #define PINMUX_PIN_54_EQEP1B                 ((uint32)((uint32)0x8U <<  PINMUX_PIN_54_SHIFT))
 

--- a/BMS Workspace-git/bms-1227-fw/main.c
+++ b/BMS Workspace-git/bms-1227-fw/main.c
@@ -98,7 +98,7 @@ int main(void)
        InitializeTemperature();
        setupThermistor();
 
-        if (PINMUX_PIN_54_MIBSPI3NCS_5 == 1) { // Pin 17 on X1 connector (MIBSPI3_NCS_5) is used to indicate charging mode
+        if (CHARGER_ENABLE_PIN == 1) { // Pin 17 on X1 connector (MIBSPI3_NCS_5) is used to indicate charging mode
             BMSState = BMS_CHARGING;
         }
         else {


### PR DESCRIPTION
Major changes

- Set up global state machine: Start in BMS_RUNNING or BMS_CHARGING, and move to BMS_FAULT if a fault flag is detected. Remaining **TODO** is to send signal to Shutdown Circuit via GPIO, and to other controllers over CAN, when in BMS_FAULT state
- Integrated charger code (via charger_main.h, which is not integrated into codebase yet): Remaining **TODO** is to uncomment this when charger_main.h is integrated
- No state transition between BMS_RUNNING and BMS_CHARGING: The GPIO pin chosen to indicate charging is MIBSPI3_NCS_5 which I don't _think_ is interruptible