### PR TITLE
Minor halcogen fix

### DIFF
--- a/BMS Workspace-git/bms-1227-fw/.cproject
+++ b/BMS Workspace-git/bms-1227-fw/.cproject
@@ -235,7 +235,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="Phantom_drivers/drivers/soc/soc_unittest.c|halcogen_bms_master/mock|Phantom_drivers/mock|Phantom_drivers/phantom_pl455_unittest.c|sys_link.cmd|halcogen_bms_launchpad|halcogen_bms_master/source/sys_link.cmd|TMS570LS122xFlashLnk.cmd" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="halcogen_bms_master/source/sys_main.c|Phantom_drivers/drivers/soc/soc_unittest.c|halcogen_bms_master/mock|Phantom_drivers/mock|Phantom_drivers/phantom_pl455_unittest.c|sys_link.cmd|halcogen_bms_launchpad|halcogen_bms_master/source/sys_link.cmd|TMS570LS122xFlashLnk.cmd" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/BMS Workspace-git/bms-1227-fw/main.c
+++ b/BMS Workspace-git/bms-1227-fw/main.c
@@ -90,7 +90,7 @@ int main(void)
 
        // TODO: Initialize modern temperature here. Replaces line: InitializeTemperature() and setupThermistor()
 
-        if (CHARGER_ENABLE_PIN == 1) { // Pin 17 on X1 connector (MIBSPI3_NCS_5) is used to indicate charging mode
+        if (true) { // Pin 17 on X1 connector (MIBSPI3_NCS_5) is used to indicate charging mode
             BMSState = BMS_CHARGING;
         }
         else {


### PR DESCRIPTION
Super quick fix because the halcogen project is super outdated from a previous halcogen generation. Main problems and fixes were: 

- sys_main.c being generated (when we have our own main.c). This causes obvious compiler errors since both files have a main function. excluded sys_main.c from the build to fix
- The BMS code relied on a macro `#define CHARGER_ENABLE_PIN` that wasn't being generated anymore. Replaced with `true` in the if block it was being used in.